### PR TITLE
Add MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Calvin Rose and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I'd like to use this repository in a PR requesting that Janet support be added to GitHub's [Linguist](https://github.com/github/linguist) library. This is the library used by GitHub to recognise and highlight language syntax. It is [a condition](https://github.com/github/linguist/blob/309acde92e04c86466441afc12992274be938473/CONTRIBUTING.md) of submitting a grammar that it be licensed with a pre-approved licence (see [this list](https://github.com/github/linguist/blob/257425141d4e2a5232786bf0b13c901ada075f93/vendor/licenses/config.yml#L2-L11)).

I do not personally have a preference and have selected the MIT licence because it is the licence currently used for the main Janet repository. Please feel free to update and replace with an alternative if a different one is preferable.

Once this PR is accepted, I'm happy to make a PR to Linguist to add support for Janet.